### PR TITLE
handle non pr issue comments

### DIFF
--- a/pkg/checkmate/action.go
+++ b/pkg/checkmate/action.go
@@ -72,7 +72,12 @@ func inspect(checklists []Checklist, action *githubactions.Action) error {
 }
 
 func getPullRequestBody(ghctx *githubactions.GitHubContext) (string, error) {
-	body, ok := ghctx.Event["pull_request"].(map[string]any)["body"]
+	pullRequest, ok := ghctx.Event["pull_request"]
+	if !ok {
+		return "", nil
+	}
+
+	body, ok := pullRequest.(map[string]any)["body"]
 	if !ok || body == nil {
 		return "", nil
 	}

--- a/pkg/checkmate/action_test.go
+++ b/pkg/checkmate/action_test.go
@@ -13,20 +13,26 @@ import (
 
 func TestRun(t *testing.T) {
 	t.Run("CheckedSuccess", func(t *testing.T) {
-		action, _ := setupAction("edited-checked")
+		action, _ := setupAction("pull-request.edited-checked")
 		err := Run(context.Background(), new(Config), action, nil)
 		assert.NoError(t, err)
 	})
 
 	t.Run("UncheckedFailure", func(t *testing.T) {
-		action, _ := setupAction("edited")
+		action, _ := setupAction("pull-request.edited")
 		err := Run(context.Background(), new(Config), action, nil)
 		require.Error(t, err)
 		assert.Equal(t, "not all checklists are completed", err.Error())
 	})
 
 	t.Run("OpenedWithNullBody", func(t *testing.T) {
-		action, _ := setupAction("opened.with-null-body")
+		action, _ := setupAction("pull-request.opened.with-null-body")
+		err := Run(context.Background(), new(Config), action, nil)
+		assert.NoError(t, err)
+	})
+
+	t.Run("IssueComment", func(t *testing.T) {
+		action, _ := setupAction("issue-comment.created")
 		err := Run(context.Background(), new(Config), action, nil)
 		assert.NoError(t, err)
 	})
@@ -34,7 +40,7 @@ func TestRun(t *testing.T) {
 
 func setupAction(input string) (*githubactions.Action, *bytes.Buffer) {
 	envMap := map[string]string{
-		"GITHUB_EVENT_PATH":   fmt.Sprintf("../../test/events/pull-request.%s.json", input),
+		"GITHUB_EVENT_PATH":   fmt.Sprintf("../../test/events/%s.json", input),
 		"GITHUB_STEP_SUMMARY": "/dev/null",
 		"GITHUB_REPOSITORY":   "RoryQ/checkmate",
 	}

--- a/pkg/checkmate/commenter_test.go
+++ b/pkg/checkmate/commenter_test.go
@@ -49,7 +49,7 @@ func Test_commenter(t *testing.T) {
 	assetsChecklist := cfg.PathsChecklists[assetsGlob].ToChecklistItemsMD(assetsGlob)
 
 	t.Run("NoMatchingFiles", func(t *testing.T) {
-		action, _ := setupAction("edited")
+		action, _ := setupAction("pull-request.edited")
 		ghMockAPI := mock.NewMockedHTTPClient(
 			mock.WithRequestMatch(
 				mock.GetReposPullsFilesByOwnerByRepoByPullNumber,
@@ -66,7 +66,7 @@ func Test_commenter(t *testing.T) {
 	})
 
 	t.Run("MatchingFilesNoExistingComment", func(t *testing.T) {
-		action, _ := setupAction("edited")
+		action, _ := setupAction("pull-request.edited")
 		ghMockAPI := mock.NewMockedHTTPClient(
 			mock.WithRequestMatch(
 				mock.GetReposPullsFilesByOwnerByRepoByPullNumber,
@@ -103,7 +103,7 @@ func Test_commenter(t *testing.T) {
 	})
 
 	t.Run("MatchingFilesForSelectList", func(t *testing.T) {
-		action, _ := setupAction("edited")
+		action, _ := setupAction("pull-request.edited")
 		ghMockAPI := mock.NewMockedHTTPClient(
 			mock.WithRequestMatch(
 				mock.GetReposPullsFilesByOwnerByRepoByPullNumber,
@@ -141,7 +141,7 @@ func Test_commenter(t *testing.T) {
 	})
 
 	t.Run("MatchingFilesWithExistingComment", func(t *testing.T) {
-		action, _ := setupAction("edited")
+		action, _ := setupAction("pull-request.edited")
 		ghMockAPI := mock.NewMockedHTTPClient(
 			mock.WithRequestMatch(
 				mock.GetReposPullsFilesByOwnerByRepoByPullNumber,
@@ -168,7 +168,7 @@ func Test_commenter(t *testing.T) {
 	})
 
 	t.Run("MatchingFilesWithExistingCommentAndChangedFiles", func(t *testing.T) {
-		action, _ := setupAction("edited")
+		action, _ := setupAction("pull-request.edited")
 		schemaChecked := strings.ReplaceAll(schemaMigrationsChecklist, "[ ]", "[x]")
 		ghMockAPI := mock.NewMockedHTTPClient(
 			mock.WithRequestMatch(


### PR DESCRIPTION
Fix panic when handling non PR `issue_comment` events.

Resolves #15 