### PR TITLE
Add cancel-in-progress example

### DIFF
--- a/.github/workflows/checkmate.yaml
+++ b/.github/workflows/checkmate.yaml
@@ -11,6 +11,10 @@ on:
       - synchronize
   issue_comment:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pr-comment-master:
     env:

--- a/README.md
+++ b/README.md
@@ -46,7 +46,12 @@ Then configure the action in your workflow like
 on:
   pull_request:
     types: [edited, opened, reopened]
-    
+
+# cancel old edit events being processed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+  
 name: Checkmate
 jobs:
   validate-checklists:
@@ -74,6 +79,11 @@ on:
     types: [edited, opened, reopened, synchronize]
   issue_comment:
 
+# cancel old edit events being processed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+  
 name: Checkmate
 jobs:
   validate-checklists:


### PR DESCRIPTION
Fixes #17 

Setting concurrency and cancel in config prevents stale data being processed.